### PR TITLE
Initial parsing using ufbx

### DIFF
--- a/fbx_document.h
+++ b/fbx_document.h
@@ -103,19 +103,7 @@ private:
 			const FBXTextureIndex p_texture);
 	Error _parse_json(const String &p_path, Ref<FBXState> p_state);
 	Error _parse_glb(Ref<FileAccess> p_file, Ref<FBXState> p_state);
-	void _compute_node_heights(Ref<FBXState> p_state);
-	Error _parse_buffers(Ref<FBXState> p_state, const String &p_base_path);
-	Error _parse_buffer_views(Ref<FBXState> p_state);
 	FBXType _get_type_from_str(const String &p_string);
-	Error _parse_accessors(Ref<FBXState> p_state);
-	Error _decode_buffer_view(Ref<FBXState> p_state, double *p_dst,
-			const FBXBufferViewIndex p_buffer_view,
-			const int p_skip_every, const int p_skip_bytes,
-			const int p_element_size, const int p_count,
-			const FBXType p_type, const int p_component_count,
-			const int p_component_type, const int p_component_size,
-			const bool p_normalized, const int p_byte_offset,
-			const bool p_for_vertex);
 	Vector<double> _decode_accessor(Ref<FBXState> p_state,
 			const FBXAccessorIndex p_accessor,
 			const bool p_for_vertex);
@@ -147,17 +135,10 @@ private:
 			const FBXAccessorIndex p_accessor,
 			const bool p_for_vertex);
 	Error _parse_meshes(Ref<FBXState> p_state);
-	Ref<Image> _parse_image_bytes_into_image(Ref<FBXState> p_state, const Vector<uint8_t> &p_bytes, const String &p_mime_type, int p_index, String &r_file_extension);
+	Ref<Image> _parse_image_bytes_into_image(Ref<FBXState> p_state, const Vector<uint8_t> &p_bytes, const String &p_filename, int p_index);
 	void _parse_image_save_image(Ref<FBXState> p_state, const Vector<uint8_t> &p_bytes, const String &p_file_extension, int p_index, Ref<Image> p_image);
 	Error _parse_images(Ref<FBXState> p_state, const String &p_base_path);
-	Error _parse_textures(Ref<FBXState> p_state);
-	Error _parse_texture_samplers(Ref<FBXState> p_state);
 	Error _parse_materials(Ref<FBXState> p_state);
-	void _set_texture_transform_uv1(const Dictionary &d, Ref<BaseMaterial3D> p_material);
-	static void spec_gloss_to_metal_base_color(const Color &p_specular_factor,
-			const Color &p_diffuse,
-			Color &r_base_color,
-			float &r_metallic);
 	FBXNodeIndex _find_highest_node(Ref<FBXState> p_state,
 			const Vector<FBXNodeIndex> &p_subset);
 	void _recurse_children(Ref<FBXState> p_state, const FBXNodeIndex p_node_index,
@@ -279,7 +260,6 @@ public:
 
 public:
 	Error _parse_fbx_state(Ref<FBXState> p_state, const String &p_search_path);
-	Error _parse_fbx_extensions(Ref<FBXState> p_state);
 	void _process_mesh_instances(Ref<FBXState> p_state, Node *p_scene_root);
 	void _generate_scene_node(Ref<FBXState> p_state, const FBXNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root);
 	void _generate_skeleton_bone_node(Ref<FBXState> p_state, const FBXNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root);


### PR DESCRIPTION
Add support for parsing files using ufbx.

Currently supports most features that the GLTF parser supports:

* Nodes
* Meshes
* Skinning (reuses the skeleton forming code from GLTF)
* Materials
* Textures
* Cameras
* Animations

Blend shapes are "supported" but broken as the mesh indexing code breaks for blend shapes, need to think of a solution for that.

Animations are done in a very bare bones way. I'm thinking of adding some resampling computation logic inside ufbx, probably something like [this](https://github.com/mosra/magnum-plugins/blob/26034766daf3df76e7708d8f6b6d6d247b0f243d/src/MagnumPlugins/UfbxImporter/UfbxImporter.cpp#L1585-L1645), but shareable between projects.

Not sure if GLTF did not include lights or why they were not imported but could try to add support for those in FBX.

With skeletons there's some issues with bone scaling after unit normalization. As the scales are in the bones it makes the object's bounding box _massive_, which is not ideal. We could try to take the scale from the root bone in the hierarchy and apply it to the skeleton, but that would probably cause issues with animation.

The root node of the node hierarchy could probably be removed, so that if you would have a cube it'd just get placed in the root of the imported scene.