### PR TITLE
Fix blend shape handling.

### DIFF
--- a/thirdparty/ufbx/ufbx.c
+++ b/thirdparty/ufbx/ufbx.c
@@ -26524,18 +26524,25 @@ ufbx_abi ufbxi_noinline ufbx_matrix ufbx_catch_get_skin_vertex_matrix(ufbx_panic
 	return mat;
 }
 
-ufbx_abi ufbxi_noinline ufbx_vec3 ufbx_get_blend_shape_vertex_offset(const ufbx_blend_shape *shape, size_t vertex)
+ufbx_abi ufbxi_noinline uint32_t ufbx_get_blend_shape_offset_index(const ufbx_blend_shape *shape, size_t vertex)
 {
 	ufbx_assert(shape);
-	if (!shape) return ufbx_zero_vec3;
+	if (!shape) return UFBX_NO_INDEX;
 
 	size_t index = SIZE_MAX;
 	uint32_t vertex_ix = (uint32_t)vertex;
 
 	ufbxi_macro_lower_bound_eq(uint32_t, 16, &index, shape->offset_vertices.data, 0, shape->num_offsets,
 		( *a < vertex_ix ), ( *a == vertex_ix ));
-	if (index == SIZE_MAX) return ufbx_zero_vec3;
+	if (index >= UINT32_MAX) return UFBX_NO_INDEX;
 
+	return (uint32_t)index;
+}
+
+ufbx_abi ufbxi_noinline ufbx_vec3 ufbx_get_blend_shape_vertex_offset(const ufbx_blend_shape *shape, size_t vertex)
+{
+	uint32_t index = ufbx_get_blend_shape_offset_index(shape, vertex);
+	if (index == UFBX_NO_INDEX) return ufbx_zero_vec3;
 	return shape->position_offsets.data[index];
 }
 

--- a/thirdparty/ufbx/ufbx.h
+++ b/thirdparty/ufbx/ufbx.h
@@ -4455,6 +4455,7 @@ ufbx_inline ufbx_matrix ufbx_get_skin_vertex_matrix(const ufbx_skin_deformer *sk
 	return ufbx_catch_get_skin_vertex_matrix(NULL, skin, vertex, fallback);
 }
 
+ufbx_abi uint32_t ufbx_get_blend_shape_offset_index(const ufbx_blend_shape *shape, size_t vertex);
 ufbx_abi ufbx_vec3 ufbx_get_blend_shape_vertex_offset(const ufbx_blend_shape *shape, size_t vertex);
 ufbx_abi ufbx_vec3 ufbx_get_blend_vertex_offset(const ufbx_blend_deformer *blend, size_t vertex);
 


### PR DESCRIPTION
Should fix #13.

The core of the issue here is that geometry data in FBX is not indexed, so there is no way to map from the processed array mesh into blend shape offsets after `mesh_surface_tool->index()` is called. I assume that blend shapes are currently broken for non-indexed glTF meshes as well.

To fix this we need to retain vertex index information during this process, but as we have no extra geometry data channels to use currently I did a somewhat strange fix: Instead of storing vertex positions directly in `Mesh::ARRAY_VERTEX`, for meshes with blend shapes we store instead `Vector3(index & 0xffff, index >> 16, 0)`. This prevents the `index()` call from merging vertices that are in the same position but have potentially different blend offsets, but still allows merging identical vertices by index.

Afterwards it's easy to retrieve the vertex indices for generating the blend shape data. The real vertex positions are later patched in after blend shapes are read.

Edited:

Fixes: https://github.com/V-Sekai/godot-ufbx/issues/10
Fixes: https://github.com/V-Sekai/godot-ufbx/issues/13